### PR TITLE
Define ObjSpaceViewDir in Fragment Shader

### DIFF
--- a/CGIncludes/UnityCG.glslinc
+++ b/CGIncludes/UnityCG.glslinc
@@ -48,6 +48,12 @@ uniform vec4 _LightPositionRange; // xyz = pos, w = 1/range
 #define USING_LIGHT_MULTI_COMPILE
 #endif
 
+// Computes object space view direction
+vec3 ObjSpaceViewDir( vec4 v )
+{
+    vec3 objSpaceCameraPos = (unity_WorldToObject * vec4(_WorldSpaceCameraPos.xyz, 1.0)).xyz;
+    return objSpaceCameraPos - v.xyz;
+}
 
 #ifdef VERTEX
 
@@ -85,13 +91,6 @@ vec3 ObjSpaceLightDir( vec4 v )
 vec3 WorldSpaceViewDir( vec4 v )
 {
     return _WorldSpaceCameraPos.xyz - (unity_ObjectToWorld * v).xyz;
-}
-
-// Computes object space view direction
-vec3 ObjSpaceViewDir( vec4 v )
-{
-    vec3 objSpaceCameraPos = (unity_WorldToObject * vec4(_WorldSpaceCameraPos.xyz, 1.0)).xyz;
-    return objSpaceCameraPos - v.xyz;
 }
 
 // Declares 3x3 matrix 'rotation', filled with tangent space basis


### PR DESCRIPTION
When calling `ObjSpaceViewDir()` Per Vertex from the Vertex Shader there is visible Warbling to Texture3D due to inaccuracies missed which are correct when calling the same method Per Fragment from the Fragment Shader.
Either allow calling of this method from both Shader Programs or provide a separate implementation for each.
### Standard Method in the Vertex Shader before edit
![ObjSpaceViewDirPerVertex](https://user-images.githubusercontent.com/8195854/156979876-3decdb97-fb88-4940-84b9-f727cc4a6e0e.png)
### Self-Defined Method in the Fragment Shader after edit
![ObjSpaceViewDirPerFragment](https://user-images.githubusercontent.com/8195854/156979896-279ff35e-3a18-4eb4-b8a1-7ff7df4ca022.png)

#### This is what I used to fix it in my own volumetric shader, though I shouldn't have to write it again as such.
```
            vec3 ObjSpaceViewDirFragment(vec4 pos)
            {
                vec3 objSpaceCameraPos = (unity_WorldToObject * vec4(_WorldSpaceCameraPos.xyz, 1.0)).xyz;
                return objSpaceCameraPos - pos.xyz;
            }
```
#### Pending an update with a correction to the Vertex Shader implementation of this method to remove the Warbling...

